### PR TITLE
add users management commands

### DIFF
--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree
 from ckan_cloud_operator.deis_ckan.instance import DeisCkanInstance
 from ckan_cloud_operator.infra import CkanInfra
 from ckan_cloud_operator import gcloud
+from ckan_cloud_operator import kubectl
 from ckan_cloud_operator.gitlab import CkanGitlab
 import ckan_cloud_operator.routers
 import ckan_cloud_operator.users
@@ -147,15 +148,22 @@ def users_update(name):
     great_success()
 
 
-@users.command('delete')
-def users_delete(name):
-    ckan_cloud_operator.users.delete(name)
-    great_success()
-
-
 @users.command('get')
+@click.argument('NAME')
 def users_get(name):
     print(yaml.dump(ckan_cloud_operator.users.get(name), default_flow_style=False))
+
+
+@users.command('delete')
+@click.argument('NAME')
+def users_delete(name):
+    ckan_cloud_operator.users.delete(name)
+
+
+@users.command('list')
+@click.argument('ARGS', nargs=-1)
+def users_list(args):
+    kubectl.call('get CkanCloudUser ' + ' '.join(args))
 
 
 #################################

--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -12,6 +12,7 @@ from ckan_cloud_operator.infra import CkanInfra
 from ckan_cloud_operator import gcloud
 from ckan_cloud_operator.gitlab import CkanGitlab
 import ckan_cloud_operator.routers
+import ckan_cloud_operator.users
 
 
 CLICK_CLI_MAX_CONTENT_WIDTH = 200
@@ -72,6 +73,7 @@ def install_crds():
     """Install ckan-cloud-operator custom resource definitions"""
     DeisCkanInstance.install_crd()
     ckan_cloud_operator.routers.install_crds()
+    ckan_cloud_operator.users.install_crds()
     great_success()
 
 
@@ -114,6 +116,46 @@ def bash_completion():
     print('# ')
     print('# To enable Bash completion, use the following command:')
     print('# eval "$(ckan-cloud-operator bash-completion)"')
+
+
+#################################
+####                         ####
+####         users           ####
+####                         ####
+#################################
+
+
+@main.group()
+def users():
+    """Manage ckan-cloud-operator users"""
+    pass
+
+
+@users.command('create')
+@click.argument('NAME')
+@click.argument('ROLE')
+def users_create(name, role):
+    ckan_cloud_operator.users.create(name, role)
+    ckan_cloud_operator.users.update(name)
+    great_success()
+
+
+@users.command('update')
+@click.argument('NAME')
+def users_update(name):
+    ckan_cloud_operator.users.update(name)
+    great_success()
+
+
+@users.command('delete')
+def users_delete(name):
+    ckan_cloud_operator.users.delete(name)
+    great_success()
+
+
+@users.command('get')
+def users_get(name):
+    print(yaml.dump(ckan_cloud_operator.users.get(name), default_flow_style=False))
 
 
 #################################

--- a/ckan_cloud_operator/infra.py
+++ b/ckan_cloud_operator/infra.py
@@ -27,6 +27,7 @@ class CkanInfra(object):
         self.GCLOUD_SERVICE_ACCOUNT_EMAIL = values.get('GCLOUD_SERVICE_ACCOUNT_EMAIL')
         self.GCLOUD_AUTH_PROJECT = values.get('GCLOUD_AUTH_PROJECT')
         self.MULTI_USER_STORAGE_CLASS_NAME = values.get('MULTI_USER_STORAGE_CLASS_NAME', 'cca-ckan')
+        self.GCLOUD_CLUSTER_NAME = values.get('GCLOUD_CLUSTER_NAME')
 
     @classmethod
     def set(cls, set_type, *args):

--- a/ckan_cloud_operator/kubectl.py
+++ b/ckan_cloud_operator/kubectl.py
@@ -9,6 +9,10 @@ def check_call(cmd, namespace='ckan-cloud'):
     subprocess.check_call(f'kubectl -n {namespace} {cmd}', shell=True)
 
 
+def call(cmd, namespace='ckan-cloud'):
+    return subprocess.call(f'kubectl -n {namespace} {cmd}', shell=True)
+
+
 def get(what, required=True, namespace='ckan-cloud'):
     try:
         return yaml.load(subprocess.check_output(f'kubectl -n {namespace} get {what} -o yaml', shell=True))
@@ -98,9 +102,10 @@ def create(resource, is_yaml=False):
     subprocess.run('kubectl create -f -', input=yaml.dump(resource).encode(), shell=True, check=True)
 
 
-def apply(resource, is_yaml=False):
+def apply(resource, is_yaml=False, reconcile=False):
     if is_yaml: resource = yaml.load(resource)
-    subprocess.run('kubectl apply -f -', input=yaml.dump(resource).encode(), shell=True, check=True)
+    cmd = 'auth reconcile' if reconcile else 'apply'
+    subprocess.run(f'kubectl {cmd} -f -', input=yaml.dump(resource).encode(), shell=True, check=True)
 
 
 def install_crd(plural, singular, kind):

--- a/ckan_cloud_operator/routers.py
+++ b/ckan_cloud_operator/routers.py
@@ -1,6 +1,4 @@
-import subprocess
 import yaml
-import datetime
 import toml
 import time
 from ckan_cloud_operator import kubectl

--- a/ckan_cloud_operator/users.py
+++ b/ckan_cloud_operator/users.py
@@ -1,0 +1,67 @@
+from ckan_cloud_operator import kubectl
+
+
+ROLES = {
+    'admin': {}
+}
+
+
+def create(name, role):
+    print(f'Creating CkanCloudUser {name} (role={role})')
+    assert role in ROLES
+    labels =  {'ckan-cloud/user-role': role}
+    router = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudUser', name, labels)
+    router['spec'] = {'role': role}
+    kubectl.create(router)
+
+
+def _update_user(name, role, spec, annotations):
+    print(name)
+    print(role)
+    raise Exception()
+
+
+def update(name):
+    print(f'updating CkanCloudUser {name}')
+    user = kubectl.get(f'CkanCloudUser {name}')
+    spec = user['spec']
+    role = spec['role']
+    assert role in ROLES
+    annotations = CkanUserAnnotations(name, role)
+    annotations.update_status(
+        'user', 'created',
+        lambda: _update_user(name, role, spec, annotations),
+        force_update=True
+    )
+
+
+def install_crds():
+    """Ensures installaion of the user custom resource definitions on the cluster"""
+    kubectl.install_crd('ckancloudusers', 'ckanclouduser', 'CkanCloudUser')
+
+
+class CkanUserAnnotations(kubectl.BaseAnnotations):
+    """Manage user annotations"""
+
+    @property
+    def FLAGS(self):
+        """Boolean flags which are saved as annotations on the resource"""
+        return [
+            'forceCreateAnnotations',
+        ]
+
+    @property
+    def STATUSES(self):
+        """Predefined statuses which are saved as annotations on the resource"""
+        return {
+            'user': ['created']
+        }
+
+    @property
+    def SECRET_ANNOTATIONS(self):
+        """Sensitive details which are saved in a secret related to the resource"""
+        return []
+
+    @property
+    def RESOURCE_KIND(self):
+        return 'CkanCloudUser'

--- a/ckan_cloud_operator/users.py
+++ b/ckan_cloud_operator/users.py
@@ -1,8 +1,13 @@
+import subprocess
+import yaml
 from ckan_cloud_operator import kubectl
+from ckan_cloud_operator.infra import CkanInfra
+from ckan_cloud_operator import gcloud
 
 
 ROLES = {
-    'admin': {}
+    'admin': {},
+    'manager': {}
 }
 
 
@@ -15,10 +20,180 @@ def create(name, role):
     kubectl.create(router)
 
 
-def _update_user(name, role, spec, annotations):
-    print(name)
-    print(role)
-    raise Exception()
+def _update_admin_role_user(name, service_account_name, role, labels):
+    kubectl.apply({
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRole",
+        "metadata": {
+            "name": f'ckan-cloud-admin',
+            'labels': labels
+        },
+        "rules": [
+            {
+                "apiGroups": [
+                    "*"
+                ],
+                "resources": [
+                    "*"
+                ],
+                "verbs": [
+                    "*"
+                ]
+            },
+            {
+                "nonResourceURLs": [
+                    "*"
+                ],
+                "verbs": [
+                    "*"
+                ]
+            }
+        ]
+    }, reconcile=True)
+    kubectl.apply({
+        'apiVersion': 'rbac.authorization.k8s.io/v1',
+        'kind': 'ClusterRoleBinding',
+        'metadata': {
+            'name': f'ckan-cloud-{name}-{role}',
+            'labels': labels
+        },
+        'subjects': [
+            {
+                'kind': 'User',
+                'name': f'system:serviceaccount:ckan-cloud:{service_account_name}',
+                'apiGroup': 'rbac.authorization.k8s.io'
+            }
+        ],
+        'roleRef': {
+            'kind': 'ClusterRole',
+            'name': 'ckan-cloud-admin',
+            'apiGroup': 'rbac.authorization.k8s.io'
+        }
+    }, reconcile=True)
+
+
+def _delete_admin_role_user(name, role):
+    kubectl.call(f'delete ClusterRoleBinding ckan-cloud-{name}-{role}')
+
+
+def _update_namespaced_manager_role_user(name, service_account_name, role, labels, namespace='ckan-cloud'):
+    kubectl.apply({
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {
+            "name": f'ckan-cloud-manager',
+            'namespace': namespace,
+            'labels': labels
+        },
+        "rules": [
+            {
+                "apiGroups": [
+                    "*"
+                ],
+                "resources": [
+                    "*"
+                ],
+                "verbs": [
+                    "*"
+                ]
+            }
+        ]
+    }, reconcile=True)
+    kubectl.apply({
+        'apiVersion': 'rbac.authorization.k8s.io/v1',
+        'kind': 'RoleBinding',
+        'metadata': {
+            'name': f'ckan-cloud-{name}-{role}',
+            'namespace': namespace,
+            'labels': labels
+        },
+        'subjects': [
+            {
+                'kind': 'ServiceAccount',
+                'name': service_account_name,
+                'namespace': namespace,
+            }
+        ],
+        'roleRef': {
+            'kind': 'Role',
+            'name': 'ckan-cloud-manager',
+            'namespace': namespace,
+            'apiGroup': 'rbac.authorization.k8s.io'
+        }
+    }, reconcile=True)
+
+
+def _delete_namespaced_manager_role_user(name, role):
+    kubectl.call(f'delete RoleBinding ckan-cloud-{name}-{role}')
+
+
+def _update_user(name, role):
+    assert role in ROLES
+    labels = {'ckan-cloud/user-role': role,
+              'ckan-cloud/user-name': name}
+    service_account_name = f'ckan-cloud-user-{name}'
+    kubectl.apply(kubectl.get_resource('v1', 'ServiceAccount', service_account_name, labels))
+    if role == 'admin':
+        _update_admin_role_user(name, service_account_name, role, labels)
+    elif role == 'manager':
+        _update_namespaced_manager_role_user(name, service_account_name, role, labels)
+    else:
+        raise NotImplementedError(f'unsupported role: {role}')
+
+
+def delete(name):
+    user = kubectl.get(f'CkanCloudUser {name}')
+    spec = user['spec']
+    role = spec['role']
+    assert role in ROLES
+    if role == 'admin':
+        _delete_admin_role_user(name, role)
+    elif role == 'manager':
+        _delete_namespaced_manager_role_user(name, role)
+    else:
+        raise NotImplementedError(f'unsupported role: {role}')
+    kubectl.call(f'delete ServiceAccount ckan-cloud-user-{name}')
+
+
+def get(name):
+    service_account_name = f'ckan-cloud-user-{name}'
+    service_account = kubectl.get(f'ServiceAccount {service_account_name}')
+    secret_name = service_account['secrets'][0]['name']
+    secret = kubectl.decode_secret(kubectl.get(f'secret {secret_name}'))
+    ckan_infra = CkanInfra()
+    cluster_name = ckan_infra.GCLOUD_CLUSTER_NAME
+    cluster = yaml.load(gcloud.check_output(f'container clusters describe {cluster_name}'))
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "users": [
+            {
+                "name": service_account_name,
+                "user": {
+                    "token": secret['token']
+                }
+            }
+        ],
+        "clusters": [
+            {
+                "name": cluster_name,
+                "cluster": {
+                    "server": 'https://' + cluster['endpoint'],
+                    "certificate-authority-data": cluster['masterAuth']['clusterCaCertificate']
+                }
+            }
+        ],
+        "contexts": [
+            {
+                "name": cluster_name,
+                "context": {
+                    "cluster": cluster_name,
+                    "user": service_account_name
+                }
+            }
+        ],
+        "current-context": cluster_name
+    }
 
 
 def update(name):
@@ -27,10 +202,10 @@ def update(name):
     spec = user['spec']
     role = spec['role']
     assert role in ROLES
-    annotations = CkanUserAnnotations(name, role)
+    annotations = CkanUserAnnotations(name, user)
     annotations.update_status(
         'user', 'created',
-        lambda: _update_user(name, role, spec, annotations),
+        lambda: _update_user(name, role),
         force_update=True
     )
 


### PR DESCRIPTION
child of https://github.com/ViderumGlobal/PM/issues/5
fixes https://github.com/ViderumGlobal/PM/issues/52

* Added ckan-cloud-operator users command group
* Uses CkanCloudUser CRD to manage users
* Each user has a role:
  * `admin` - full cluster admin
  * `manager` - full permissions only on `ckan-cloud` namespace