### PR TITLE
Centralized datapushers support + migration

### DIFF
--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -505,14 +505,22 @@ def routers_traefik():
 @click.argument('API_KEY')
 @click.option('--wait-ready', is_flag=True)
 def routers_traefik_enable_letsencrypt_cloudflare(traefik_router_name, email, api_key, wait_ready):
-    ckan_cloud_operator.routers.traefik(
-        'enable-letsencrypt-cloudflare',
+    ckan_cloud_operator.routers.traefik_enable_letsencrypt_cloudflare(
         traefik_router_name,
-        (email, api_key)
+        email,
+        api_key
     )
     ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
     great_success()
 
+@routers_traefik.command('set-default-root-domain')
+@click.argument('TRAEFIK_ROUTER_NAME')
+@click.argument('DEFAULT_ROOT_DOMAIN')
+@click.option('--wait-ready', is_flag=True)
+def routers_traefik_set_default_root_domain(traefik_router_name, default_root_domain, wait_ready):
+    ckan_cloud_operator.routers.traefik_set_default_root_domain(traefik_router_name, default_root_domain)
+    ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
+    great_success()
 
 @routers_traefik.command('set-deis-instance-subdomain-route')
 @click.argument('TRAEFIK_ROUTER_NAME')
@@ -524,10 +532,25 @@ def routers_traefik_enable_letsencrypt_cloudflare(traefik_router_name, email, ap
 def routers_traefik_set_deis_instance_route(traefik_router_name, deis_instance_id, root_domain,
                                             sub_domain, route_name, wait_ready):
     deis_instance = DeisCkanInstance(deis_instance_id)
-    ckan_cloud_operator.routers.traefik(
-        'set-deis-instance-subdomain-route',
+    ckan_cloud_operator.routers.traefik_set_deis_instance_subdomain_route(
         traefik_router_name,
-        (deis_instance, root_domain, sub_domain, route_name)
+        deis_instance,
+        root_domain,
+        sub_domain,
+        route_name
+    )
+    ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
+    great_success()
+
+@routers_traefik.command('set-deis-instance-default-subdomain-route')
+@click.argument('TRAEFIK_ROUTER_NAME')
+@click.argument('DEIS_INSTANCE_ID')
+@click.option('--wait-ready', is_flag=True)
+def routers_traefik_set_deis_instance_default_subdomain_route(traefik_router_name, deis_instance_id, wait_ready):
+    deis_instance = DeisCkanInstance(deis_instance_id)
+    ckan_cloud_operator.routers.traefik_set_instance_default_subdomain_route(
+        traefik_router_name,
+        deis_instance
     )
     ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
     great_success()
@@ -535,7 +558,7 @@ def routers_traefik_set_deis_instance_route(traefik_router_name, deis_instance_i
 @routers_traefik.command('delete')
 @click.argument('TRAEFIK_ROUTER_NAME')
 def routers_traefik_delete(traefik_router_name):
-    ckan_cloud_operator.routers.traefik('delete', traefik_router_name)
+    ckan_cloud_operator.routers.traefik_delete(traefik_router_name)
 
 
 @routers_traefik.command('set-datapusher-subdomain-route')
@@ -547,10 +570,12 @@ def routers_traefik_delete(traefik_router_name):
 @click.option('--wait-ready', is_flag=True)
 def routers_traefik_set_datapushers_subdomain_route(traefik_router_name, datapusher_name, root_domain,
                                                     sub_domain, route_name, wait_ready):
-    ckan_cloud_operator.routers.traefik(
-        'set-datapusher-subdomain-route',
+    ckan_cloud_operator.routers.traefik_set_datapusher_subdomain_route(
         traefik_router_name,
-        (datapusher_name, root_domain, sub_domain, route_name)
+        datapusher_name,
+        root_domain,
+        sub_domain,
+        route_name
     )
     ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
     great_success()

--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -599,11 +599,18 @@ def datapushers_update(datapusher_name):
 
 
 @datapushers.command('list')
-def datapushers_list():
-    print(yaml.dump(ckan_cloud_operator.datapushers.list(), default_flow_style=False))
+@click.option('--full', is_flag=True)
+def datapushers_list(full):
+    print(yaml.dump(ckan_cloud_operator.datapushers.list(full=full), default_flow_style=False))
 
 
 @datapushers.command('get')
 @click.argument('DATAPUSHER_NAME')
 def datapushers_get(datapusher_name):
     print(yaml.dump(ckan_cloud_operator.datapushers.get(datapusher_name), default_flow_style=False))
+
+@datapushers.command('delete')
+@click.argument('DATAPUSHER_NAME')
+def datapushers_delete(datapusher_name):
+    ckan_cloud_operator.datapushers.delete(datapusher_name)
+    great_success()

--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -15,6 +15,7 @@ from ckan_cloud_operator.gitlab import CkanGitlab
 import ckan_cloud_operator.routers
 import ckan_cloud_operator.users
 import ckan_cloud_operator.storage
+import ckan_cloud_operator.datapushers
 
 
 CLICK_CLI_MAX_CONTENT_WIDTH = 200
@@ -76,6 +77,7 @@ def install_crds():
     DeisCkanInstance.install_crd()
     ckan_cloud_operator.routers.install_crds()
     ckan_cloud_operator.users.install_crds()
+    ckan_cloud_operator.datapushers.install_crds()
     great_success()
 
 
@@ -530,8 +532,78 @@ def routers_traefik_set_deis_instance_route(traefik_router_name, deis_instance_i
     ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
     great_success()
 
+@routers_traefik.command('delete')
+@click.argument('TRAEFIK_ROUTER_NAME')
+def routers_traefik_delete(traefik_router_name):
+    ckan_cloud_operator.routers.traefik('delete', traefik_router_name)
+
+
+@routers_traefik.command('set-datapusher-subdomain-route')
+@click.argument('TRAEFIK_ROUTER_NAME')
+@click.argument('DATAPUSHER_NAME')
+@click.argument('ROOT_DOMAIN')
+@click.argument('SUB_DOMAIN')
+@click.argument('ROUTE_NAME')
+@click.option('--wait-ready', is_flag=True)
+def routers_traefik_set_datapushers_subdomain_route(traefik_router_name, datapusher_name, root_domain,
+                                                    sub_domain, route_name, wait_ready):
+    ckan_cloud_operator.routers.traefik(
+        'set-datapusher-subdomain-route',
+        traefik_router_name,
+        (datapusher_name, root_domain, sub_domain, route_name)
+    )
+    ckan_cloud_operator.routers.update(traefik_router_name, wait_ready)
+    great_success()
+
 
 @routers.command('get')
 @click.argument('ROUTER_NAME')
 def get(router_name):
     print(yaml.dump(ckan_cloud_operator.routers.get(router_name), default_flow_style=False))
+
+
+#################################
+####                         ####
+####      datapushers        ####
+####                         ####
+#################################
+
+
+@main.group()
+def datapushers():
+    """Manage centralized CKAN DataPushers"""
+    pass
+
+
+@datapushers.command('create')
+@click.argument('DATAPUSHER_NAME')
+@click.argument('DOCKER_IMAGE')
+@click.argument('PATH_TO_CONFIG_YAML')
+def datapushers_create(datapusher_name, docker_image, path_to_config_yaml):
+    """Create and update a DataPusher deployment
+
+    Example:
+
+        ckan-cloud-operator datapushers create datapusher-1 registry.gitlab.com/viderum/docker-datapusher:cloud-datapusher-1-v9 /path/to/datapusher-1.yaml
+    """
+    ckan_cloud_operator.datapushers.create(datapusher_name, docker_image, path_to_config_yaml)
+    ckan_cloud_operator.datapushers.update(datapusher_name)
+    great_success()
+
+
+@datapushers.command('update')
+@click.argument('DATAPUSHER_NAME')
+def datapushers_update(datapusher_name):
+    ckan_cloud_operator.datapushers.update(datapusher_name)
+    great_success()
+
+
+@datapushers.command('list')
+def datapushers_list():
+    print(yaml.dump(ckan_cloud_operator.datapushers.list(), default_flow_style=False))
+
+
+@datapushers.command('get')
+@click.argument('DATAPUSHER_NAME')
+def datapushers_get(datapusher_name):
+    print(yaml.dump(ckan_cloud_operator.datapushers.get(datapusher_name), default_flow_style=False))

--- a/ckan_cloud_operator/datapushers.py
+++ b/ckan_cloud_operator/datapushers.py
@@ -1,0 +1,145 @@
+import yaml
+from ckan_cloud_operator import kubectl
+from ckan_cloud_operator.infra import CkanInfra
+
+
+def install_crds():
+    """Ensures installaion of the datapusher custom resource definitions on the cluster"""
+    kubectl.install_crd('ckanclouddatapushers', 'ckanclouddatapusher', 'CkanCloudDatapusher')
+
+
+def create(name, image, path_to_config_yaml):
+    with open(path_to_config_yaml) as f:
+        config = yaml.load(f)
+    labels =  _get_labels(name)
+    datapusher = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudDatapusher', name, labels)
+    datapusher['spec'] = {'image': image,
+                          'config': config}
+    kubectl.create(datapusher)
+
+
+def update(name):
+    _update_registry_secret()
+    datapusher = kubectl.get(f'CkanCloudDatapusher {name}')
+    deployment_name = get_deployment_name(name)
+    labels = _get_labels(name)
+    spec = _get_deployment_spec(labels, datapusher['spec'])
+    print(f'Updating CkanCloudDatapusher {name} (deployment_name={deployment_name})')
+    deployment = kubectl.get_deployment(deployment_name, labels, spec)
+    kubectl.apply(deployment)
+
+
+def update_service(name):
+    labels = _get_labels(name)
+    service = kubectl.get_resource('v1', 'Service', get_service_name(name), labels)
+    service['spec'] = {
+        'ports': [
+            {'name': '8000', 'port': 8000}
+        ],
+        'selector': labels
+    }
+    kubectl.apply(service)
+
+
+def get_service_url(name):
+    service_name = get_service_name(name)
+    namespace = 'ckan-cloud'
+    port = 8000
+    return f'http://{service_name}.{namespace}:{port}'
+
+
+def get(name, deployment=None):
+    deployment_name = get_deployment_name(name)
+    if not deployment:
+        deployment = kubectl.get(f'deployment {deployment_name}', required=False)
+    if deployment:
+        deployment_status = kubectl.get_deployment_detailed_status(
+            deployment,
+            f'ckan-cloud/datapusher-name={name}',
+            'datapusher'
+        )
+        ready = bool(len(deployment_status.get('errors', [])) == 0)
+    else:
+        deployment_status = {}
+        ready = False
+    return {
+        'ready': ready,
+        'name': name,
+        **deployment_status
+    }
+
+
+def list():
+    return [get(datapusher['metadata']['name']) for datapusher in kubectl.get('CkanCloudDatapusher')['items']]
+
+
+def _get_labels(name):
+    return {'ckan-cloud/datapusher-name': name}
+
+
+def get_deployment_name(name):
+    return name if name.startswith('datapusher') else f'datapusher-{name}'
+
+
+def get_service_name(name):
+    return get_deployment_name(name)
+
+
+def _get_deployment_spec(labels, spec):
+    deployment_spec = {
+        'replicas': 1,
+        'revisionHistoryLimit': 10,
+        'template': {
+            'metadata': {
+                'labels': labels
+            },
+            'spec': {
+                'imagePullSecrets': [
+                    {'name': 'datapushers-docker-registry'}
+                ],
+                'containers': [
+                    {
+                        'name': 'datapusher',
+                        'image': spec['image'],
+                        'env': [
+                            *_get_deployment_pod_envvars(spec['config']),
+                        ],
+                        'readinessProbe': {
+                            'failureThreshold': 1,
+                            'initialDelaySeconds': 5,
+                            'periodSeconds': 5,
+                            'successThreshold': 1,
+                            'tcpSocket': {
+                                'port': 8000
+                            },
+                            'timeoutSeconds': 5
+                        }
+                    }
+                ]
+            }
+        }
+    }
+    kubectl.add_operator_timestamp_annotation(deployment_spec['template']['metadata'])
+    return deployment_spec
+
+
+def _get_deployment_pod_envvars(config):
+    return [{'name': k, 'value': v} for k, v in config.items()]
+
+
+def _update_registry_secret():
+    secret = kubectl.get('secret datapushers-docker-registry', required=False)
+    if secret:
+        print('Secret already exists, delete to recreate: datapushers-registry-secret')
+    else:
+        ckan_infra = CkanInfra()
+        print('Creating datapushers registry secret')
+        docker_server = ckan_infra.DOCKER_REGISTRY_SERVER
+        docker_username = ckan_infra.DOCKER_REGISTRY_USERNAME
+        docker_password = ckan_infra.DOCKER_REGISTRY_PASSWORD
+        docker_email = ckan_infra.DOCKER_REGISTRY_EMAIL
+        kubectl.check_call(f'create secret docker-registry datapushers-docker-registry '
+                           f'--docker-password={docker_password} '
+                           f'--docker-server={docker_server} '
+                           f'--docker-username={docker_username} '
+                           f'--docker-email={docker_email}')

--- a/ckan_cloud_operator/deis_ckan/ckan.py
+++ b/ckan_cloud_operator/deis_ckan/ckan.py
@@ -47,7 +47,8 @@ class DeisCkanInstanceCKAN(object):
         """Start port forwarding to the CKAN deployment, using the CKAN varnish port 5000 by default"""
         if len(args) == 0:
             args = ['5000']
-        self.instance.kubectl(f'port-forward deployment/{self.instance.id} ' + " ".join(args))
+        pod_name = self._get_ckan_pod_name()
+        self.instance.kubectl(f'port-forward {pod_name} ' + " ".join(args))
         subprocess.check_call(['kubectl', '-n', self.instance.id, 'port-forward', f'deployment/{self.instance.id}', *args])
 
     def _create(self):

--- a/ckan_cloud_operator/deis_ckan/datapusher.py
+++ b/ckan_cloud_operator/deis_ckan/datapusher.py
@@ -1,0 +1,23 @@
+from ckan_cloud_operator import kubectl
+from urllib.parse import urlparse
+
+
+def get_datapusher_url(instance_datapusher_url):
+    if instance_datapusher_url and len(instance_datapusher_url) > 10:
+        hostname = urlparse(instance_datapusher_url).hostname
+        if hostname.endswith('.ckan.io'):
+            datapusher_name = hostname.replace('.ckan.io', '')
+            routes = kubectl.get(
+                f'CkanCloudRoute -l ckan-cloud/datapusher-name={datapusher_name},ckan-cloud/route-type=datapusher-subdomain',
+                required=False
+            )
+            if routes:
+                routes = routes.get('items', [])
+                if len(routes) > 0:
+                    assert len(routes) == 1
+                    route = routes[0]
+                    return 'https://{}.{}/'.format(
+                        route['spec']['sub-domain'],
+                        route['spec']['root-domain'],
+                    )
+    return None

--- a/ckan_cloud_operator/deis_ckan/envvars.py
+++ b/ckan_cloud_operator/deis_ckan/envvars.py
@@ -54,6 +54,7 @@ class DeisCkanInstanceEnvvars(object):
             CKANEXT__S3FILESTORE__REGION_NAME=ckan_infra.GCLOUD_STORAGE_REGION_NAME,
             CKANEXT__S3FILESTORE__SIGNATURE_VERSION=ckan_infra.GCLOUD_STORAGE_SIGNATURE_VERSION,
         )
+        print(envvars)
         instance_envvars_secret = {'apiVersion': 'v1',
                                    'kind': 'Secret',
                                    'metadata': {

--- a/ckan_cloud_operator/deis_ckan/envvars.py
+++ b/ckan_cloud_operator/deis_ckan/envvars.py
@@ -54,7 +54,6 @@ class DeisCkanInstanceEnvvars(object):
             CKANEXT__S3FILESTORE__REGION_NAME=ckan_infra.GCLOUD_STORAGE_REGION_NAME,
             CKANEXT__S3FILESTORE__SIGNATURE_VERSION=ckan_infra.GCLOUD_STORAGE_SIGNATURE_VERSION,
         )
-        print(envvars)
         instance_envvars_secret = {'apiVersion': 'v1',
                                    'kind': 'Secret',
                                    'metadata': {

--- a/ckan_cloud_operator/deis_ckan/envvars.py
+++ b/ckan_cloud_operator/deis_ckan/envvars.py
@@ -4,6 +4,7 @@ import base64
 import json
 from ckan_cloud_operator import kubectl
 from ckan_cloud_operator.gitlab import CkanGitlab
+from ckan_cloud_operator.deis_ckan import datapusher
 
 
 class DeisCkanInstanceEnvvars(object):
@@ -53,6 +54,7 @@ class DeisCkanInstanceEnvvars(object):
             CKANEXT__S3FILESTORE__HOST_NAME=f'https://{ckan_infra.GCLOUD_STORAGE_BUCKET}.{ckan_infra.GCLOUD_STORAGE_HOST_NAME}/',
             CKANEXT__S3FILESTORE__REGION_NAME=ckan_infra.GCLOUD_STORAGE_REGION_NAME,
             CKANEXT__S3FILESTORE__SIGNATURE_VERSION=ckan_infra.GCLOUD_STORAGE_SIGNATURE_VERSION,
+            CKAN__DATAPUSHER__URL=datapusher.get_datapusher_url(envvars.get('CKAN__DATAPUSHER__URL')),
         )
         instance_envvars_secret = {'apiVersion': 'v1',
                                    'kind': 'Secret',

--- a/ckan_cloud_operator/infra.py
+++ b/ckan_cloud_operator/infra.py
@@ -34,6 +34,7 @@ class CkanInfra(object):
         self.GCLOUD_STORAGE_HOST_NAME = values.get('GCLOUD_STORAGE_HOST_NAME')
         self.GCLOUD_STORAGE_REGION_NAME = values.get('GCLOUD_STORAGE_REGION_NAME')
         self.GCLOUD_STORAGE_SIGNATURE_VERSION = values.get('GCLOUD_STORAGE_SIGNATURE_VERSION')
+        self.ROUTERS_ENV_ID = values.get('ROUTERS_ENV_ID')
 
     @classmethod
     def set(cls, set_type, *args):

--- a/ckan_cloud_operator/kubectl.py
+++ b/ckan_cloud_operator/kubectl.py
@@ -3,6 +3,7 @@ import subprocess
 import base64
 import traceback
 import datetime
+import json
 
 
 def check_call(cmd, namespace='ckan-cloud'):
@@ -209,6 +210,11 @@ class BaseAnnotations(object):
         return []
 
     @property
+    def JSON_ANNOTATION_PREFIXES(self):
+        """flexible annotations encoded to json and permitted using key prefixes"""
+        return []
+
+    @property
     def RESOURCE_KIND(self):
         raise NotImplementedError()
 
@@ -343,6 +349,16 @@ class BaseAnnotations(object):
                 }
             }
         }
+
+    def json_annotate(self, key, value, overwrite=True):
+        ans = []
+        assert any([key.startswith(prefix) for prefix in self.JSON_ANNOTATION_PREFIXES]), f'invalid json annotation key: {key}'
+        value = json.dumps(value)
+        ans.append(f"{key}='{value}'")
+        self._annotate(*ans, overwrite=overwrite)
+
+    def get_json_annotation(self, key):
+        return json.loads(self._get_annotation(key))
 
     def _annotate(self, *annotations, overwrite=False):
         cmd = f'kubectl -n ckan-cloud annotate {self.resource_kind} {self.resource_id}'

--- a/ckan_cloud_operator/routers.py
+++ b/ckan_cloud_operator/routers.py
@@ -179,17 +179,18 @@ def _update_traefik_deployment(name, ckan_infra, spec, annotations, routes):
             sub_domain = route_spec['sub-domain']
             domains.setdefault(root_domain, []).append(sub_domain)
             deis_instance_id = route_spec['deis-instance-id']
-            print(f'updating route name {route_name} for deis instance {deis_instance_id}')
-            route_service = kubectl.get_resource('v1', 'Service', route_name, labels, namespace=deis_instance_id)
-            route_service['spec'] = {
-                'ports': [
-                    {'name': '5000', 'port': 5000}
-                ],
-                'selector': {
-                    'app': 'ckan'
+            if kubectl.get(f'ns {deis_instance_id}', required=False):
+                print(f'updating route name {route_name} for deis instance {deis_instance_id}')
+                route_service = kubectl.get_resource('v1', 'Service', route_name, labels, namespace=deis_instance_id)
+                route_service['spec'] = {
+                    'ports': [
+                        {'name': '5000', 'port': 5000}
+                    ],
+                    'selector': {
+                        'app': 'ckan'
+                    }
                 }
-            }
-            kubectl.apply(route_service)
+                kubectl.apply(route_service)
         elif route_type == 'datapusher-subdomain':
             route_name = route['metadata']['name']
             root_domain = route_spec['root-domain']
@@ -332,87 +333,80 @@ def _init_traefik_router(name):
     return router, annotations, ckan_infra
 
 
-def traefik(command, router_name, args=None):
-    if command == 'enable-letsencrypt-cloudflare':
-        print('Enabling SSL using lets encrypt and cloudflare')
-        router, annotations, ckan_infra = _init_traefik_router(router_name)
-        cloudflare_email, cloudflare_api_key = args
-        annotations.update_flag('letsencryptCloudflareEnabled', lambda: annotations.set_secrets({
-            'LETSENCRYPT_CLOUDFLARE_EMAIL': cloudflare_email,
-            'LETSENCRYPT_CLOUDFLARE_API_KEY': cloudflare_api_key
-        }), force_update=True)
-    elif command == 'set-default-root-domain':
-        root_domain = args[0]
-        print(f'Setting default root domain for router {router_name} to {root_domain}')
-        router, annotations, ckan_infra = _init_traefik_router(router_name)
+def traefik_enable_letsencrypt_cloudflare(router_name, cloudflare_email, cloudflare_api_key):
+    print('Enabling SSL using lets encrypt and cloudflare')
+    router, annotations, ckan_infra = _init_traefik_router(router_name)
+    annotations.update_flag('letsencryptCloudflareEnabled', lambda: annotations.set_secrets({
+        'LETSENCRYPT_CLOUDFLARE_EMAIL': cloudflare_email,
+        'LETSENCRYPT_CLOUDFLARE_API_KEY': cloudflare_api_key
+    }), force_update=True)
 
-    elif command == 'set-deis-instance-subdomain-route':
-        deis_instance, root_domain, sub_domain, route_name = args
-        print(f'Setting deis instance route from {sub_domain}.{root_domain} to deis ckan instance id {deis_instance.id}')
-        labels = {'ckan-cloud/router-type': 'traefik',
-                  'ckan-cloud/router-name': router_name,
-                  'ckan-cloud/route-type': 'deis-instance-subdomain'}
-        route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
-        route['spec'] = {'type': 'deis-instance-subdomain',
-                         'root-domain': root_domain,
-                         'sub-domain': sub_domain,
-                         'deis-instance-id': deis_instance.id}
-        kubectl.apply(route)
-    elif command == 'set-deis-instance-default-subdomain-route':
-        deis_instance = args[0]
-        sub_domain = f'cc-{cc_env_id}-{deis_instance}'
-        root_domain = True
-        router = get(router_name)
 
-        print(f'Setting deis instance default route from {sub_domain}.{root_domain} to deis ckan instance id {deis_instance.id}')
-        labels = {'ckan-cloud/router-type': 'traefik',
-                  'ckan-cloud/router-name': router_name,
-                  'ckan-cloud/route-type': 'deis-instance-subdomain'}
-        route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
-        route['spec'] = {'type': 'deis-instance-subdomain',
-                         'root-domain': root_domain,
-                         'sub-domain': sub_domain,
-                         'deis-instance-id': deis_instance.id}
-        kubectl.apply(route)
-    elif command == 'set-datapusher-subdomain-route':
-        datapusher_name, root_domain, sub_domain, route_name = args
-        print(f'Setting datapusher route from {sub_domain}.{root_domain} to datapusher name {datapusher_name}')
-        labels = {'ckan-cloud/router-type': 'traefik',
-                  'ckan-cloud/router-name': router_name,
-                  'ckan-cloud/route-type': 'datapusher-subdomain',
-                  'ckan-cloud/datapusher-name': datapusher_name}
-        route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
-        route['spec'] = {'type': 'datapusher-subdomain',
-                         'root-domain': root_domain,
-                         'sub-domain': sub_domain,
-                         'datapusher-name': datapusher_name}
-        kubectl.apply(route)
-    elif command == 'delete':
-        assert not args
-        print(f'Deleting traefik router {router_name}')
-        if all([
-            kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} deployment') == 0,
-            kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} service') == 0,
-            kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} CkanCloudRoute') == 0,
-            kubectl.call(f'delete --ignore-not-found CkanCloudRouter {router_name}') == 0,
-        ]):
-            print('Removing finalizers')
-            success = True
-            for route in kubectl.get(f'CkanCloudRoute -l ckan-cloud/router-name={router_name}')['items']:
-                route_name = route['metadata']['name']
-                if kubectl.call(
-                    f'patch CkanCloudRoute {route_name} -p \'{{"metadata":{{"finalizers":[]}}}}\' --type=merge',
-                ) != 0:
-                    success = False
+def traefik_set_default_root_domain(router_name, root_domain):
+    print(f'Setting default root domain for router {router_name} to {root_domain}')
+    router, annotations, ckan_infra = _init_traefik_router(router_name)
+    annotations.json_annotate('default-root-domain', root_domain)
+
+
+def traefik_set_deis_instance_subdomain_route(router_name, deis_instance, root_domain, sub_domain, route_name):
+    print(f'Setting deis instance route from {sub_domain}.{root_domain} to deis ckan instance id {deis_instance.id}')
+    labels = {'ckan-cloud/router-type': 'traefik',
+              'ckan-cloud/router-name': router_name,
+              'ckan-cloud/route-type': 'deis-instance-subdomain'}
+    route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
+    route['spec'] = {'type': 'deis-instance-subdomain',
+                     'root-domain': root_domain,
+                     'sub-domain': sub_domain,
+                     'deis-instance-id': deis_instance.id}
+    kubectl.apply(route)
+
+
+def traefik_set_instance_default_subdomain_route(router_name, deis_instance):
+    router, annotations, ckan_infra = _init_traefik_router(router_name)
+    assert ckan_infra.ROUTERS_ENV_ID
+    sub_domain = f'cc-{ckan_infra.ROUTERS_ENV_ID}-{deis_instance.id}'
+    root_domain = annotations.get_json_annotation('default-root-domain')
+    route_name = f'deis-instance-{deis_instance.id}-default'
+    return traefik_set_deis_instance_subdomain_route(router_name, deis_instance, root_domain, sub_domain, route_name)
+
+
+def traefik_set_datapusher_subdomain_route(router_name, datapusher_name, root_domain, sub_domain, route_name):
+    print(f'Setting datapusher route from {sub_domain}.{root_domain} to datapusher name {datapusher_name}')
+    labels = {'ckan-cloud/router-type': 'traefik',
+              'ckan-cloud/router-name': router_name,
+              'ckan-cloud/route-type': 'datapusher-subdomain',
+              'ckan-cloud/datapusher-name': datapusher_name}
+    route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
+    route['spec'] = {'type': 'datapusher-subdomain',
+                     'root-domain': root_domain,
+                     'sub-domain': sub_domain,
+                     'datapusher-name': datapusher_name}
+    kubectl.apply(route)
+
+
+def traefik_delete(router_name):
+    print(f'Deleting traefik router {router_name}')
+    if all([
+        kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} deployment') == 0,
+        kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} service') == 0,
+        kubectl.call(f'delete --ignore-not-found -l ckan-cloud/router-name={router_name} CkanCloudRoute') == 0,
+        kubectl.call(f'delete --ignore-not-found CkanCloudRouter {router_name}') == 0,
+    ]):
+        print('Removing finalizers')
+        success = True
+        for route in kubectl.get(f'CkanCloudRoute -l ckan-cloud/router-name={router_name}')['items']:
+            route_name = route['metadata']['name']
             if kubectl.call(
-                f'patch CkanCloudRouter {router_name} -p \'{{"metadata":{{"finalizers":[]}}}}\' --type=merge',
+                    f'patch CkanCloudRoute {route_name} -p \'{{"metadata":{{"finalizers":[]}}}}\' --type=merge',
             ) != 0:
                 success = False
-            assert success
-        else:
-            raise Exception('Deletion failed')
+        if kubectl.call(
+                f'patch CkanCloudRouter {router_name} -p \'{{"metadata":{{"finalizers":[]}}}}\' --type=merge',
+        ) != 0:
+            success = False
+        assert success
     else:
-        raise NotImplementedError(f'Invalid traefik command: {command} {args}')
+        raise Exception('Deletion failed')
 
 
 class CkanRoutersAnnotations(kubectl.BaseAnnotations):
@@ -440,6 +434,11 @@ class CkanRoutersAnnotations(kubectl.BaseAnnotations):
             'LETSENCRYPT_CLOUDFLARE_EMAIL',
             'LETSENCRYPT_CLOUDFLARE_API_KEY'
         ]
+
+    @property
+    def JSON_ANNOTATION_PREFIXES(self):
+        """flexible annotations encoded to json and permitted using key prefixes"""
+        return ['default-root-domain']
 
     @property
     def RESOURCE_KIND(self):

--- a/ckan_cloud_operator/routers.py
+++ b/ckan_cloud_operator/routers.py
@@ -358,7 +358,8 @@ def traefik(command, router_name, args=None):
         print(f'Setting datapusher route from {sub_domain}.{root_domain} to datapusher name {datapusher_name}')
         labels = {'ckan-cloud/router-type': 'traefik',
                   'ckan-cloud/router-name': router_name,
-                  'ckan-cloud/route-type': 'datapusher-subdomain'}
+                  'ckan-cloud/route-type': 'datapusher-subdomain',
+                  'ckan-cloud/datapusher-name': datapusher_name}
         route = kubectl.get_resource('stable.viderum.com/v1', 'CkanCloudRoute', route_name, labels)
         route['spec'] = {'type': 'datapusher-subdomain',
                          'root-domain': root_domain,

--- a/docs/IMPORT-DEIS.md
+++ b/docs/IMPORT-DEIS.md
@@ -132,6 +132,14 @@ ckan-cloud-operator initialize-gitlab <REPO_NAME>
 
 Follow the gitlab build to get the Docker image
 
+## Initialize the DataPusher
+
+Get the relevant DataPusher image from Rancher
+
+ssh to one of the old cluster servers, tag and push the image to `registry.gitlab.com/viderum/docker-datapusher:cloud-<DATAPUSHER_IMAGE_TAG>`
+
+Use the image to create the DataPusher using ckan-cloud-operator datapushers create command
+
 ## create an instance using ckan-cloud-operator
 
 Use [ckan-cloud-operator](https://github.com/ViderumGlobal/ckan-cloud-operator) to create an instance using deis-instance create from-gcloud-envvars command

--- a/docs/IMPORT-DEIS.md
+++ b/docs/IMPORT-DEIS.md
@@ -134,6 +134,8 @@ Follow the gitlab build to get the Docker image
 
 ## Initialize the DataPusher
 
+all datapushers were migrated, this step is probably not needed anymore, unless we find a new datapusher being used somewhere
+
 Get the relevant DataPusher image from Rancher
 
 ssh to one of the old cluster servers, tag and push the image to `registry.gitlab.com/viderum/docker-datapusher:cloud-<DATAPUSHER_IMAGE_TAG>`


### PR DESCRIPTION
* Added support for datapusher custom objects
* Added datapushers corresponding to old cluster datapushers
* Added support for adding routes from datapusher instances to external domains using the traefik routers
* Added support for default root/sub domains to deis instances/routers
* Added readiness probe for the ckan instances for zero downtime deployments