### PR TITLE
fix various problems with db process, datastore and connection pooler

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,23 @@ Enable Bash completion
 ```
 eval "$(ckan-cloud-operator bash-completion)"
 ```
+
+## Using Jupyter Lab
+
+Jupyter Lab can be used to run bulk operations or aggregate data from ckan-cloud-operator
+
+You should run ckan-cloud-operator locally and run the following from the activated ckan-cloud-operator environment
+
+Install jupyterlab
+
+```
+python3 -m pip install jupyterlab
+```
+
+Run jupyterlab
+
+```
+jupyter lab
+```
+
+Open notebooks from the `notebooks` directory

--- a/ckan_cloud_operator/cli.py
+++ b/ckan_cloud_operator/cli.py
@@ -20,6 +20,7 @@ from ckan_cloud_operator import kubectl
 from ckan_cloud_operator import logs
 
 from ckan_cloud_operator.providers import cli as providers_cli
+from ckan_cloud_operator.db import cli as db_cli
 
 
 CLICK_CLI_MAX_CONTENT_WIDTH = 200
@@ -37,6 +38,7 @@ def main():
 
 
 main.add_command(providers_cli.providers_group, 'providers')
+main.add_command(db_cli.db_group, 'db')
 
 
 @main.command('cluster-info')

--- a/ckan_cloud_operator/db/cli.py
+++ b/ckan_cloud_operator/db/cli.py
@@ -1,0 +1,41 @@
+import click
+import time
+
+from ckan_cloud_operator.db import manager as db_manager
+
+
+@click.group()
+def db_group():
+    """Manage the centralized db"""
+    pass
+
+
+@db_group.command()
+@click.option('--initialize', is_flag=True)
+def web_ui(initialize):
+    """Start a web-UI for db management"""
+    if initialize:
+        db_manager.initialize_web_ui()
+        time.sleep(5)
+    db_manager.web_ui()
+
+
+@db_group.command()
+@click.option('--admin', is_flag=True)
+@click.option('--deis-instance')
+@click.option('--datastore', is_flag=True)
+@click.option('--datastore-ro', is_flag=True)
+def connection_string(admin, deis_instance, datastore, datastore_ro):
+    """Get a DB connection string
+
+    Example: psql -d $(ckan-cloud-operator db connection-string --admin)
+    """
+    if admin:
+        assert not deis_instance and not datastore and not datastore_ro
+        print(db_manager.get_external_admin_connection_string())
+    elif deis_instance:
+        assert not admin
+        print(db_manager.get_deis_instsance_external_connection_string(deis_instance, is_datastore=datastore,
+                                                                       is_datastore_readonly=datastore_ro))
+    else:
+        raise Exception('invalid arguments')

--- a/ckan_cloud_operator/db/manager.py
+++ b/ckan_cloud_operator/db/manager.py
@@ -1,12 +1,18 @@
+import os
+
 from ckan_cloud_operator import kubectl
 
 from ckan_cloud_operator.providers.manager import get_provider
+from ckan_cloud_operator.providers.service import set_provider
+from ckan_cloud_operator.providers.db_web_ui.constants import PROVIDER_SUBMODULE as db_web_ui_submodule
+from ckan_cloud_operator.providers.db_web_ui.adminer.constants import PROVIDER_ID as adminer_provider_id
+from ckan_cloud_operator.infra import CkanInfra
 
 
-def update():
+def update(deis_instance_id=None):
     db_proxy_manager = get_provider('db-proxy', required=False)
     if db_proxy_manager:
-        db_proxy_manager.update()
+        db_proxy_manager.update(deis_instance_id=deis_instance_id)
 
 
 def get_all_dbs_users():
@@ -36,10 +42,75 @@ def get_all_dbs_users():
 
 
 def get_admin_db_credentials():
-    return get_provider('db').get_postgres_admin_credentials()
+    admin_user, admin_password, db_name = get_provider('db').get_postgres_admin_credentials()
+    return admin_user, admin_password, db_name
+
+
+def get_external_admin_connection_string(db_name=None):
+    """Get an admin connection string for access from outside the cluster"""
+    admin_user, admin_password, admin_db_name = get_admin_db_credentials()
+    if not db_name:
+        db_name = admin_db_name
+    db_host, db_port = get_external_proxy_host_port()
+    return f'postgresql://{admin_user}:{admin_password}@{db_host}:{db_port}/{db_name}'
+
+
+def get_deis_instsance_external_connection_string(instance_id, is_datastore=False, is_datastore_readonly=False):
+    user, password, db_name, db_host, db_port = get_deis_instance_external_connection_details(
+        instance_id, is_datastore=is_datastore, is_datastore_readonly=is_datastore_readonly
+    )
+    return f'postgresql://{user}:{password}@{db_host}:{db_port}/{db_name}'
+
+
+def get_deis_instance_credentials(instance_id, is_datastore=False, is_datastore_readonly=False, required=True):
+    none = None, None, None
+    instance = kubectl.get(f'DeisCkanInstance {instance_id}', required=required)
+    if not instance: return none
+    secret = kubectl.get(f'secret {instance_id}-annotations', namespace=instance_id, required=required)
+    if not secret: return none
+    secret = kubectl.decode_secret(secret)
+    if is_datastore or is_datastore_readonly:
+        db_name = user = instance['spec'].get('datastore', {}).get('name')
+        if is_datastore_readonly:
+            user = secret.get('datastoreReadonlyUser')
+            password = secret.get('datatastoreReadonlyPassword')
+        else:
+            password = secret.get('datastorePassword')
+    else:
+        db_name = user = instance['spec'].get('db', {}).get('name')
+        password = secret.get('databasePassword')
+    res = [user, password, db_name]
+    if all(res):
+        return res
+    else:
+        assert not required, 'missing some db values'
+        return none
+
+
+def get_deis_instance_internal_connection_details(instance_id, is_datastore=False, is_datastore_readonly=False, required=True):
+    user, password, db_name = get_deis_instance_credentials(instance_id, is_datastore, is_datastore_readonly, required)
+    db_host, db_port = get_internal_proxy_host_port()
+    res = [user, password, db_name, db_host, db_port]
+    if all(res):
+        return res
+    else:
+        assert not required, 'missing some db values'
+        return None, None, None, None, None
+
+
+def get_deis_instance_external_connection_details(instance_id, is_datastore=False, is_datastore_readonly=False, required=True):
+    user, password, db_name = get_deis_instance_credentials(instance_id, is_datastore, is_datastore_readonly, required)
+    db_host, db_port = get_external_proxy_host_port()
+    res = [user, password, db_name, db_host, db_port]
+    if all(res):
+        return res
+    else:
+        assert not required, 'missing some db values'
+        return None, None, None, None, None
 
 
 def get_internal_proxy_host_port():
+    """Returns connection details for internal cluster access"""
     db_proxy_manager = get_provider('db-proxy', required=False)
     if db_proxy_manager:
         db_host, db_port = db_proxy_manager.get_internal_proxy_host_port()
@@ -47,3 +118,33 @@ def get_internal_proxy_host_port():
         db_manager = get_provider('db')
         db_host, db_port = db_manager.get_postgres_host_port()
     return db_host, db_port
+
+
+def get_external_proxy_host_port():
+    """Returns connection details for access from outside the cluster"""
+    if os.environ.get('CKAN_CLOUD_OPERATOR_USE_PROXY') in ['yes', '1', 'true']:
+        return '127.0.0.1', 5432
+    else:
+        raise Exception('direct access to the DB is not supported from external operators')
+
+
+def web_ui():
+    print('\n')
+    print('Starting DB web-ui')
+    print('\n')
+    admin_user, admin_password, db_name = get_admin_db_credentials()
+    db_manager = get_provider('db')
+    db_host, db_port = db_manager.get_postgres_host_port()
+    print(f'admin db name: {db_name}')
+    print('\n')
+    print(f'{admin_user} password: {admin_password}')
+    url = f'http://localhost:8080/?pgsql={db_host}&username={admin_user}'
+    print('\n')
+    print(f'Use the following url to open adminer: {url}')
+    print('\n')
+    get_provider(db_web_ui_submodule).web_ui()
+
+
+def initialize_web_ui():
+    set_provider(db_web_ui_submodule, adminer_provider_id)
+    get_provider(db_web_ui_submodule).initialize()

--- a/ckan_cloud_operator/db/manager.py
+++ b/ckan_cloud_operator/db/manager.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from ckan_cloud_operator import kubectl
 
@@ -148,3 +149,9 @@ def web_ui():
 def initialize_web_ui():
     set_provider(db_web_ui_submodule, adminer_provider_id)
     get_provider(db_web_ui_submodule).initialize()
+
+
+def check_db_exists(db_name):
+    admin_db_connection_string = get_external_admin_connection_string()
+    cmd = f"psql -d {admin_db_connection_string} -c \"select 1 from pg_database where datname='{db_name}';\" -t"
+    return subprocess.check_output(cmd, shell=True).decode().strip() == '1'

--- a/ckan_cloud_operator/deis_ckan/envvars.py
+++ b/ckan_cloud_operator/deis_ckan/envvars.py
@@ -49,8 +49,8 @@ class DeisCkanInstanceEnvvars(object):
         envvars.update(
             CKAN_SQLALCHEMY_URL=f"postgresql://{db_name}:{db_password}@{postgres_host}:{postgres_port}/{db_name}",
             CKAN___BEAKER__SESSION__URL=f"postgresql://{db_name}:{db_password}@{postgres_host}:{postgres_port}/{db_name}",
-            CKAN__DATASTORE__READ_URL=f"postgresql://{datastore_ro_user}:{datastore_ro_password}@{postgres_host}:5432/{datastore_name}",
-            CKAN__DATASTORE__WRITE_URL=f"postgresql://{datastore_name}:{datastore_password}@{postgres_host}:5432/{datastore_name}",
+            CKAN__DATASTORE__READ_URL=f"postgresql://{datastore_ro_user}:{datastore_ro_password}@{postgres_host}:{postgres_port}/{datastore_name}",
+            CKAN__DATASTORE__WRITE_URL=f"postgresql://{datastore_name}:{datastore_password}@{postgres_host}:{postgres_port}/{datastore_name}",
             CKAN_SOLR_URL=f"{solr_http_endpoint}/{solr_collection_name}",
             # we are using the non-authenticated proxy, so this has to be disabled to prevent ckans which support auth from using them
             # CKAN_SOLR_USER=ckan_infra.SOLR_USER,

--- a/ckan_cloud_operator/infra.py
+++ b/ckan_cloud_operator/infra.py
@@ -88,7 +88,7 @@ class CkanInfra(object):
             print("Keep this running in the background")
             print("Set the following environment variable to cause ckan-cloud-operator to connect via the proxy")
             print("export CKAN_CLOUD_OPERATOR_USE_PROXY=yes")
-            subprocess.check_call(f'kubectl -n ckan-cloud port-forward deployment/cloudsql-proxy 5432', shell=True)
+            subprocess.check_call(f'kubectl -n ckan-cloud port-forward deployment/ckan-cloud-db-proxy-pgbouncer 5432', shell=True)
 
         @command_group.command('deploy-solr-proxy')
         def deploy_ckan_infra_solr_proxy():

--- a/ckan_cloud_operator/kubectl.py
+++ b/ckan_cloud_operator/kubectl.py
@@ -10,6 +10,10 @@ def check_call(cmd, namespace='ckan-cloud'):
     subprocess.check_call(f'kubectl -n {namespace} {cmd}', shell=True)
 
 
+def check_output(cmd, namespace='ckan-cloud'):
+    return subprocess.check_output(f'kubectl -n {namespace} {cmd}', shell=True)
+
+
 def call(cmd, namespace='ckan-cloud'):
     return subprocess.call(f'kubectl -n {namespace} {cmd}', shell=True)
 

--- a/ckan_cloud_operator/kubectl.py
+++ b/ckan_cloud_operator/kubectl.py
@@ -41,9 +41,20 @@ def decode_secret(secret, attr=None, required=False):
         else:
             return {}
     elif attr:
-        return base64.b64decode(secret['data'][attr]).decode()
+        if required:
+            return base64.b64decode(secret['data'][attr]).decode()
+        else:
+            value = secret.get('data', {}).get(attr)
+            if value:
+                return base64.b64decode(value)
+            else:
+                return None
     else:
-        return {k: base64.b64decode(v).decode() for k, v in secret['data'].items()}
+        return {
+            k: base64.b64decode(v).decode() if v else None
+            for k, v
+            in secret.get('data', {}).items()
+        }
 
 
 def update_secret(name, values, namespace='ckan-cloud', labels=None):

--- a/ckan_cloud_operator/providers/db_proxy/pgbouncer/cli.py
+++ b/ckan_cloud_operator/providers/db_proxy/pgbouncer/cli.py
@@ -20,7 +20,8 @@ def initialize():
 
 
 @pgbouncer_group.command()
-def update():
+@click.option('--deis-instance')
+def update(deis_instance):
     """Update with all currently enabled instance db details"""
-    pgbouncer_manager.update()
+    pgbouncer_manager.update(deis_instance_id=deis_instance)
     logs.exit_great_success()

--- a/ckan_cloud_operator/providers/db_proxy/pgbouncer/manager.py
+++ b/ckan_cloud_operator/providers/db_proxy/pgbouncer/manager.py
@@ -104,7 +104,6 @@ def _apply_config_secret(deis_instance_id=None, wait_updated=False):
             line_user, line_password = [k.strip('"') for k in line.split(' ')]
             if line_user in update_users:
                 password = update_users.pop(line_user)
-                updated_line = f'"{line_user}" "{password}"'
                 users_txt.append(f'"{line_user}" "{password}"')
             else:
                 users_txt.append(line)

--- a/ckan_cloud_operator/providers/db_proxy/pgbouncer/manager.py
+++ b/ckan_cloud_operator/providers/db_proxy/pgbouncer/manager.py
@@ -1,6 +1,8 @@
 import datetime
+import time
 
 from ckan_cloud_operator import kubectl
+from ckan_cloud_operator import logs
 
 from ckan_cloud_operator.providers.labels import get_provider_labels, get_provider_label_prefix
 from ckan_cloud_operator.providers.db_proxy.constants import PROVIDER_SUBMODULE
@@ -11,13 +13,17 @@ from ckan_cloud_operator.cluster.constants import OPERATOR_NAMESPACE
 
 
 def initialize():
-    update()
-
-
-def update():
     _apply_config_secret()
     _apply_service()
     _apply_deployment()
+
+
+def update(deis_instance_id=None):
+    _apply_config_secret(deis_instance_id=deis_instance_id, wait_updated=True)
+    for pod_name in kubectl.check_output(
+        f'get pods -l app=ckan-cloud-db-proxy-pgbouncer --output=custom-columns=name:.metadata.name --no-headers'
+    ).decode().splitlines():
+        kubectl.check_call(f'exec {pod_name} -- pgbouncer -q -u pgbouncer -d -R /var/local/pgbouncer/pgbouncer.ini')
 
 
 def set_as_main_db_proxy():
@@ -29,15 +35,56 @@ def get_internal_proxy_host_port():
     return f'{label_prefix}.{OPERATOR_NAMESPACE}', 5432
 
 
-def _apply_config_secret():
+def _apply_config_secret(deis_instance_id=None, wait_updated=False):
     label_prefix = get_provider_label_prefix(PROVIDER_SUBMODULE, PROVIDER_ID)
-    dbs, users = db_manager.get_all_dbs_users()
+    update_dbs = {}
+    update_users = {}
+    if deis_instance_id:
+        user, password, db_name, db_host, db_port = db_manager.get_deis_instance_internal_connection_details(
+            deis_instance_id, required=False
+        )
+        if all([user, password, db_name, db_host, db_port]):
+            assert db_name not in update_dbs
+            update_dbs[db_name] = f'{db_name} = host={db_host} port={db_port} dbname={db_name}'
+            assert user not in update_users
+            update_users[user] = password
+        user, password, db_name, db_host, db_port = db_manager.get_deis_instance_internal_connection_details(
+            deis_instance_id, is_datastore=True, required=False
+        )
+        if all([user, password, db_name, db_host, db_port]):
+            assert db_name not in update_dbs
+            update_dbs[db_name] = f'{db_name} = host={db_host} port={db_port} dbname={db_name}'
+            assert user not in update_users
+            update_users[user] = password
+        user, password, db_name, db_host, db_port = db_manager.get_deis_instance_internal_connection_details(
+            deis_instance_id, is_datastore=True, is_datastore_readonly=True, required=False
+        )
+        if all([user, password, db_name, db_host, db_port]):
+            assert user not in update_users
+            update_users[user] = password
+    else:
+        dbs, users = db_manager.get_all_dbs_users()
+        for db_name, db_host, db_port in dbs:
+            assert db_name not in update_dbs
+            update_dbs[db_name] = f'{db_name} = host={db_host} port={db_port} dbname={db_name}'
+        for name, password in users:
+            assert name not in users
+            update_users[name] = password
     pg_bouncer_ini = ["[databases]"]
-    all_db_names = set()
-    for db_name, db_host, db_port in dbs:
-        assert db_name not in all_db_names
-        pg_bouncer_ini.append(f'{db_name} = host={db_host} port={db_port} dbname={db_name}')
-        all_db_names.add(db_name)
+    if deis_instance_id:
+        secret = kubectl.decode_secret(kubectl.get(f'secret {label_prefix}-config'))
+        for line in secret['pgbouncer.ini'].splitlines():
+            if line == '[databases]': continue
+            elif line == '': break
+            else:
+                line_db_name = line.split(' ')[0]
+                if line_db_name in update_dbs:
+                    update_line = update_dbs.pop(line_db_name)
+                    pg_bouncer_ini.append(update_line)
+                else:
+                    pg_bouncer_ini.append(line)
+    for db_name, line in update_dbs.items():
+        pg_bouncer_ini.append(line)
     db_admin_user, _, _ = db_manager.get_admin_db_credentials()
     pg_bouncer_ini += [
         "",
@@ -51,14 +98,45 @@ def _apply_config_secret():
         f"admin_users = {db_admin_user}",
     ]
     users_txt = []
-    for name, password in users:
+    if deis_instance_id:
+        secret = kubectl.decode_secret(kubectl.get(f'secret {label_prefix}-config'))
+        for line in secret['users.txt'].splitlines():
+            line_user, line_password = [k.strip('"') for k in line.split(' ')]
+            if line_user in update_users:
+                password = update_users.pop(line_user)
+                updated_line = f'"{line_user}" "{password}"'
+                users_txt.append(f'"{line_user}" "{password}"')
+            else:
+                users_txt.append(line)
+    for name, password in update_users.items():
         users_txt.append(f'"{name}" "{password}"')
-    pg_bouncer_ini = "\n".join(pg_bouncer_ini)
-    users_txt = "\n".join(users_txt)
-    kubectl.update_secret(f'{label_prefix}-config', {
-        'pgbouncer.ini': pg_bouncer_ini,
-        'users.txt': users_txt
-    }, labels=get_provider_labels(PROVIDER_SUBMODULE, PROVIDER_ID))
+    updated_secret = {
+        'pgbouncer.ini': "\n".join(pg_bouncer_ini),
+        'users.txt': "\n".join(users_txt)
+    }
+    kubectl.update_secret(
+        f'{label_prefix}-config', updated_secret,
+        labels=get_provider_labels(PROVIDER_SUBMODULE, PROVIDER_ID)
+    )
+    if wait_updated:
+        for retry_num in range(1, 20):
+            time.sleep(5)
+            if _is_secret_updated(updated_secret): break
+            logs.info(f'Waiting for updated pgbouncer secret ({retry_num}/20)..')
+
+
+def _is_secret_updated(expected_secret):
+    expected_hash =  expected_secret['users.txt'] + expected_secret['pgbouncer.ini']
+    deployment_app = get_provider_labels(PROVIDER_SUBMODULE, PROVIDER_ID, for_deployment=True)['app']
+    has_pod = False
+    for pod_name in kubectl.check_output(
+        f'get pods -l app={deployment_app} --output=custom-columns=name:.metadata.name --no-headers'
+    ).decode().splitlines():
+        has_pod = True
+        current_hash = kubectl.check_output(f'exec {pod_name} -- bash -c "cat /var/local/pgbouncer/users.txt && cat /var/local/pgbouncer/pgbouncer.ini"').decode()
+        if current_hash != expected_hash:
+            return False
+    return has_pod
 
 
 def _apply_deployment():
@@ -84,13 +162,8 @@ def _apply_deployment():
                         'volumeMounts': [
                             {
                                 'name': 'config',
-                                'mountPath': '/var/local/pgbouncer/pgbouncer.ini',
-                                'subPath': 'pgbouncer.ini'
-                            },
-                            {
-                                'name': 'config',
-                                'mountPath': '/var/local/pgbouncer/users.txt',
-                                'subPath': 'users.txt'
+                                'mountPath': '/var/local/pgbouncer',
+                                'readOnly': True
                             },
                         ]
                     }

--- a/ckan_cloud_operator/providers/db_web_ui/adminer/constants.py
+++ b/ckan_cloud_operator/providers/db_web_ui/adminer/constants.py
@@ -1,0 +1,1 @@
+PROVIDER_ID='adminer'

--- a/ckan_cloud_operator/providers/db_web_ui/adminer/manager.py
+++ b/ckan_cloud_operator/providers/db_web_ui/adminer/manager.py
@@ -1,0 +1,60 @@
+import datetime
+
+from ckan_cloud_operator import kubectl
+
+from ckan_cloud_operator.providers.db_web_ui.constants import PROVIDER_SUBMODULE
+from ckan_cloud_operator.providers.db_web_ui.adminer.constants import PROVIDER_ID
+from ckan_cloud_operator.providers import service as providers_service
+from ckan_cloud_operator.providers import labels as providers_labels
+
+
+def initialize():
+    update()
+
+
+def update():
+    _apply_deployment()
+
+
+def web_ui():
+    label_prefix = _get_label_prefix()
+    kubectl.check_call(f'port-forward deployment/{label_prefix} 8080')
+
+
+def _apply_deployment():
+    deployment_labels = _get_labels(for_deployment=True)
+    label_prefix = _get_label_prefix()
+    kubectl.apply(kubectl.get_deployment(label_prefix, deployment_labels, {
+        'replicas': 1,
+        'revisionHistoryLimit': 2,
+        'strategy': {'type': 'RollingUpdate', },
+        'template': {
+            'metadata': {
+                'labels': deployment_labels,
+                'annotations': {
+                    'ckan-cloud/operator-timestamp': str(datetime.datetime.now())
+                }
+            },
+            'spec': {
+                'containers': [
+                    {
+                        'name': 'adminer',
+                        'image': 'adminer',
+                        'ports': [{'containerPort': 8080}],
+                    }
+                ],
+            }
+        }
+    }))
+
+
+def _set_provider():
+    providers_service.set_provider(PROVIDER_SUBMODULE, PROVIDER_ID)
+
+
+def _get_label_prefix():
+    return providers_labels.get_provider_label_prefix(PROVIDER_SUBMODULE, PROVIDER_ID)
+
+
+def _get_labels(for_deployment=False):
+    return providers_labels.get_provider_labels(PROVIDER_SUBMODULE, PROVIDER_ID, for_deployment=for_deployment)

--- a/ckan_cloud_operator/providers/db_web_ui/constants.py
+++ b/ckan_cloud_operator/providers/db_web_ui/constants.py
@@ -1,0 +1,1 @@
+PROVIDER_SUBMODULE='db-web-ui'

--- a/ckan_cloud_operator/providers/manager.py
+++ b/ckan_cloud_operator/providers/manager.py
@@ -8,6 +8,10 @@ from ckan_cloud_operator.providers.db.constants import PROVIDER_SUBMODULE as db_
 from ckan_cloud_operator.providers.db.gcloudsql.constants import PROVIDER_ID as gcloudsql_provider_id
 from ckan_cloud_operator.providers.db.gcloudsql import manager as gcloudsql_manager
 
+from ckan_cloud_operator.providers.db_web_ui.constants import PROVIDER_SUBMODULE as db_web_ui_submodule
+from ckan_cloud_operator.providers.db_web_ui.adminer.constants import PROVIDER_ID as adminer_provider_id
+from ckan_cloud_operator.providers.db_web_ui.adminer import manager as adminer_manager
+
 
 def get_provider(submodule, required=True):
     provider_id = get_cached_configmap_value(f'{submodule}-provider-id')
@@ -16,15 +20,24 @@ def get_provider(submodule, required=True):
             raise Exception(f'No provider found for {submodule}')
         else:
             return None
+
     elif submodule == db_proxy_provider_submodule:
         if provider_id == pgbouncer_provider_id:
             return pgbouncer_manager
         else:
             raise Exception(f'Invalid provider for {db_proxy_provider_submodule}: {provider_id}')
+
     elif submodule == db_provider_submodule:
         if provider_id == gcloudsql_provider_id:
             return gcloudsql_manager
         else:
             raise Exception(f'Invalid provider  for {db_provider_submodule}: {provider_id}')
+
+    elif submodule == db_web_ui_submodule:
+        if provider_id == adminer_provider_id:
+            return adminer_manager
+        else:
+            raise Exception(f'Invalid provider  for {db_web_ui_submodule}: {provider_id}')
+
     else:
         raise Exception(f'Invalid submodule: {submodule}')

--- a/ckan_cloud_operator/providers/manager.py
+++ b/ckan_cloud_operator/providers/manager.py
@@ -2,15 +2,12 @@ from ckan_cloud_operator.config.manager import get_cached_configmap_value
 
 from ckan_cloud_operator.providers.db_proxy.constants import PROVIDER_SUBMODULE as db_proxy_provider_submodule
 from ckan_cloud_operator.providers.db_proxy.pgbouncer.constants import PROVIDER_ID as pgbouncer_provider_id
-from ckan_cloud_operator.providers.db_proxy.pgbouncer import manager as pgbouncer_manager
 
 from ckan_cloud_operator.providers.db.constants import PROVIDER_SUBMODULE as db_provider_submodule
 from ckan_cloud_operator.providers.db.gcloudsql.constants import PROVIDER_ID as gcloudsql_provider_id
-from ckan_cloud_operator.providers.db.gcloudsql import manager as gcloudsql_manager
 
 from ckan_cloud_operator.providers.db_web_ui.constants import PROVIDER_SUBMODULE as db_web_ui_submodule
 from ckan_cloud_operator.providers.db_web_ui.adminer.constants import PROVIDER_ID as adminer_provider_id
-from ckan_cloud_operator.providers.db_web_ui.adminer import manager as adminer_manager
 
 
 def get_provider(submodule, required=True):
@@ -23,18 +20,21 @@ def get_provider(submodule, required=True):
 
     elif submodule == db_proxy_provider_submodule:
         if provider_id == pgbouncer_provider_id:
+            from ckan_cloud_operator.providers.db_proxy.pgbouncer import manager as pgbouncer_manager
             return pgbouncer_manager
         else:
             raise Exception(f'Invalid provider for {db_proxy_provider_submodule}: {provider_id}')
 
     elif submodule == db_provider_submodule:
         if provider_id == gcloudsql_provider_id:
+            from ckan_cloud_operator.providers.db.gcloudsql import manager as gcloudsql_manager
             return gcloudsql_manager
         else:
             raise Exception(f'Invalid provider  for {db_provider_submodule}: {provider_id}')
 
     elif submodule == db_web_ui_submodule:
         if provider_id == adminer_provider_id:
+            from ckan_cloud_operator.providers.db_web_ui.adminer import manager as adminer_manager
             return adminer_manager
         else:
             raise Exception(f'Invalid provider  for {db_web_ui_submodule}: {provider_id}')

--- a/ckan_cloud_operator/providers/service.py
+++ b/ckan_cloud_operator/providers/service.py
@@ -1,5 +1,12 @@
 from ckan_cloud_operator.config.manager import set_configmap_values
+from ckan_cloud_operator.config.manager import get_cached_configmap_value
 
 
 def set_provider(submodule, provider_id):
     set_configmap_values({f'{submodule}-provider-id': provider_id})
+
+
+def get_provider_id(submodule, required=True):
+    provider_id = get_cached_configmap_value(f'{submodule}-provider-id')
+    assert provider_id or not required
+    return provider_id

--- a/ckan_cloud_operator/routers/cli.py
+++ b/ckan_cloud_operator/routers/cli.py
@@ -3,7 +3,7 @@ import yaml
 
 from ckan_cloud_operator.routers import manager as routers_manager
 from ckan_cloud_operator.routers.routes import manager as routes_manager
-from ckan_cloud_operator import kubectl
+from ckan_cloud_operator import logs
 
 
 def add_cli_commands(click, command_group, great_success):
@@ -98,6 +98,20 @@ def add_cli_commands(click, command_group, great_success):
                     'frontend-hostname': routes_manager.get_frontend_hostname(route),
                 }
                 print(yaml.dump([data], default_flow_style=False))
+
+    @command_group.command('delete-routes')
+    @click.option('-p', '--datapusher-name', required=False)
+    @click.option('-d', '--deis-instance-id', required=False)
+    @click.option('-r', '--root-domain', required=False)
+    @click.option('-s', '--sub-domain', required=False)
+    def delete_routes(datapusher_name, deis_instance_id, root_domain, sub_domain):
+        routers_manager.delete_routes(
+            datapusher_name=datapusher_name,
+            deis_instance_id=deis_instance_id,
+            root_domain=root_domain,
+            sub_domain=sub_domain
+        )
+        logs.exit_great_success()
 
     @command_group.command('delete')
     @click.argument('ROUTER_NAME')

--- a/notebooks/bulk-migration-testing.ipynb
+++ b/notebooks/bulk-migration-testing.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bulk Migrate Instances"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get list of existing instance ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import subprocess\n",
+    "\n",
+    "EXISTING_INSTANCE_IDS=[i['id'] for i in yaml.load(subprocess.check_output(\"ckan-cloud-operator deis-instance list --quick\", shell=True))]\n",
+    "print(yaml.dump(EXISTING_INSTANCE_IDS, default_flow_style=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Duplicate all the existing instance ids with a prefix\n",
+    "\n",
+    "Set a prefix for the new instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PREFIX = 'ori-test'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import all the existing instances to new instances with the given prefix\n",
+    "\n",
+    "You can follow the log in jupyter lab output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "for instance_id in EXISTING_INSTANCE_IDS:\n",
+    "    subprocess.call(f'ckan-cloud-operator deis-instance delete {PREFIX}-{instance_id}', shell=True)\n",
+    "    subprocess.call(f'ckan-cloud-operator deis-instance delete --force {PREFIX}-{instance_id}', shell=True)\n",
+    "    subprocess.check_call(\n",
+    "        f'ckan-cloud-operator deis-instance migrate {instance_id} {PREFIX}-{instance_id} production-1',\n",
+    "        shell=True\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Migrate a single instance\n",
+    "\n",
+    "set the instance id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OLD_INSTANCE_ID='aberdeen'\n",
+    "NEW_INSTANCE_ID='ori-test-aberdeen'\n",
+    "ROUTER_NAME='production-1'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Delete the new instance (if it exists)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subprocess.call(\n",
+    "    f'ckan-cloud-operator deis-instance delete {NEW_INSTANCE_ID}', \n",
+    "    shell=True\n",
+    "), subprocess.call(\n",
+    "    f'ckan-cloud-operator deis-instance delete {NEW_INSTANCE_ID} --force',\n",
+    "    shell=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Migrate the instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subprocess.check_call(\n",
+    "        f'ckan-cloud-operator deis-instance migrate {OLD_INSTANCE_ID} {NEW_INSTANCE_ID} {ROUTER_NAME}',\n",
+    "        shell=True\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* added DB web-ui: `ckan-cloud-operator db web-ui`
* fixed various problems with db migration and setup process
* fixes to connection pooler
* fixed checks of existing DB
* increment suffix to db name in case it already exists (as re-using existing db name doesn't work)
* add commands to delete routes
* delete routes on instance deletion
* added jupyter notebook for bulk migration and testing