### PR TITLE
try executing datastore permission command one by one

### DIFF
--- a/ckan_cloud_operator/datastore_permissions.py
+++ b/ckan_cloud_operator/datastore_permissions.py
@@ -1,4 +1,4 @@
-DATASTORE_PERMISSIONS_SQL_TEMPLATE = """
+DATASTORE_PERMISSIONS_SQL_TEMPLATE = ["""
 CREATE OR REPLACE VIEW "_table_metadata" AS
     SELECT DISTINCT
         substr(md5(dependee.relname || COALESCE(dependent.relname, '')), 0, 17) AS "_id",
@@ -18,9 +18,14 @@ CREATE OR REPLACE VIEW "_table_metadata" AS
         AND dependee.relnamespace = (
             SELECT oid FROM pg_namespace WHERE nspname='public')
     ORDER BY dependee.oid DESC;
+""",
+"""
 ALTER VIEW "_table_metadata" OWNER TO "{{SITE_USER}}";
+""",
+"""
 GRANT SELECT ON "_table_metadata" TO "{{DS_RO_USER}}";
-
+""",
+"""
 CREATE OR REPLACE FUNCTION populate_full_text_trigger() RETURNS trigger
 AS $body$
     BEGIN
@@ -34,8 +39,11 @@ AS $body$
         RETURN NEW;
     END;
 $body$ LANGUAGE plpgsql;
+""",
+"""
 ALTER FUNCTION populate_full_text_trigger() OWNER TO "{{SITE_USER}}";
-
+""",
+"""
 DO $body$
     BEGIN
         EXECUTE coalesce(
@@ -53,3 +61,4 @@ DO $body$
     END;
 $body$;
 """
+]

--- a/ckan_cloud_operator/deis_ckan/db.py
+++ b/ckan_cloud_operator/deis_ckan/db.py
@@ -138,8 +138,12 @@ class DeisCkanInstanceDb(object):
             f"REASSIGN OWNED BY \"{postgres_user}\" TO \"{db_name}\";",
         ]:
             self._psql(line, '-d', db_name)
-        datastore_permissions = DATASTORE_PERMISSIONS_SQL_TEMPLATE.replace('{{SITE_USER}}', site_user).replace('{{DS_RO_USER}}', ro_user)
-        self._psql(datastore_permissions, "-d", db_name)
+        for line in DATASTORE_PERMISSIONS_SQL_TEMPLATE:
+            datastore_permissions = line.replace('{{SITE_USER}}', site_user).replace('{{DS_RO_USER}}', ro_user)
+            try:
+                self._psql(datastore_permissions, "-d", db_name)
+            except Exception as e:
+                print('Failed to exectue:',  datastore_permissions)
 
     def _create_datastore_ro_user(self):
         db_name = self.db_spec['name']


### PR DESCRIPTION
@OriHoch This is related to https://github.com/ViderumGlobal/ckan-cloud-operator/issues/16 and the issue from slack:

```
nother error I'm facing with some of the instances:
```ERROR:  duplicate key value violates unique constraint "pg_type_typname_nsp_index"
DETAIL:  Key (typname, typnamespace)=(_table_metadata, 2200) already exists.
Traceback (most recent call last):
...
 File "/home/zelima/anaconda3/envs/ckan-cloud-operator/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['psql', '-v', 'ON_ERROR_STOP=on', '-h', '127.0.0.1', '-U', 'postgres', '-d', 'dundeecity-datastore', '-c', '\nCREATE OR REPLACE VIEW "_table_metadata" AS\n    SELECT DISTINCT\n        substr(md5(dependee.relname || COALESCE(dependent.relname, \'\')), 0, 17) AS "_id",\n        dependee.relname AS name,\n        dependee.oid AS oid,\n        dependent.relname AS alias_of\n    FROM\n        pg_class AS dependee\n        LEFT OUTER JOIN pg_rewrite AS r ON r.ev_class = dependee.oid\n        LEFT OUTER JOIN pg_depend AS d ON d.objid = r.oid\n        LEFT OUTER JOIN pg_class AS dependent ON d.refobjid = dependent.oid\n    WHERE\n        (dependee.oid != dependent.oid OR dependent.oid IS NULL) AND\n        -- is a table (from pg_tables view definition)\n        -- or is a view (from pg_views view definition)\n        (dependee.relkind = \'r\'::"char" OR dependee.relkind = \'v\'::"char")\n        AND dependee.relnamespace = (\n            SELECT oid FROM pg_namespace WHERE nspname=\'public\')\n    ORDER BY dependee.oid DESC;\nALTER VIEW "_table_metadata" OWNER TO "dundeecity__1";\nGRANT SELECT ON "_table_metadata" TO "dundeecity-datastore-ro";\n\nCREATE OR REPLACE FUNCTION populate_full_text_trigger() RETURNS trigger\nAS $body$\n    BEGIN\n        IF NEW._full_text IS NOT NULL THEN\n            RETURN NEW;\n        END IF;\n        NEW._full_text := (\n            SELECT to_tsvector(string_agg(value, \' \'))\n            FROM json_each_text(row_to_json(NEW.*))\n            WHERE key NOT LIKE \'\\_%\');\n        RETURN NEW;\n    END;\n$body$ LANGUAGE plpgsql;\nALTER FUNCTION populate_full_text_trigger() OWNER TO "dundeecity__1";\n\nDO $body$\n    BEGIN\n        EXECUTE coalesce(\n            (SELECT string_agg(\n                \'CREATE TRIGGER zfulltext BEFORE INSERT OR UPDATE ON \' ||\n                quote_ident(relname) || \' FOR EACH ROW EXECUTE PROCEDURE \' ||\n                \'populate_full_text_trigger();\', \' \')\n            FROM pg_class\n            LEFT OUTER JOIN pg_trigger AS t\n                ON t.tgrelid = relname::regclass AND t.tgname = \'zfulltext\'\n            WHERE relkind = \'r\'::"char" AND t.tgname IS NULL\n                AND relnamespace = (\n                    SELECT oid FROM pg_namespace WHERE nspname=\'public\')),\n            \'SELECT 1;\');\n    END;\n$body$;\n']' returned non-zero exit status 1.```
```
I'm just trying to execute each command seperatly and on error continue. 

Probabbly the temoporarry fix but, helped with migration