### PR TITLE
Consider db_prefix=" " case.

### DIFF
--- a/ckan_cloud_operator/providers/db/azuresql/manager.py
+++ b/ckan_cloud_operator/providers/db/azuresql/manager.py
@@ -59,7 +59,7 @@ def initialize(db_prefix=None, interactive=False):
 def _get_config_credentials_kwargs(db_prefix):
     return {
         'is_secret': True,
-        'suffix': f'{db_prefix}-credentials' if db_prefix else 'credentials'
+        'suffix': f'{db_prefix}-credentials' if db_prefix.strip() else 'credentials'
     }
 
 

--- a/ckan_cloud_operator/providers/db/gcloudsql/manager.py
+++ b/ckan_cloud_operator/providers/db/gcloudsql/manager.py
@@ -155,7 +155,7 @@ def _credentials_get(db_prefix, key=None, default=None, required=False):
 def _get_config_credentials_kwargs(db_prefix):
     return {
         'is_secret': True,
-        'suffix': f'{db_prefix}-credentials' if db_prefix else 'credentials'
+        'suffix': f'{db_prefix.strip()}-credentials' if db_prefix.strip() else 'credentials'
     }
 
 


### PR DESCRIPTION
Resource Name was evaluated to ckan-cloud-provider-db-gcloudsql- -credentials. Leading to kubectl error:
```
Error: unknown shorthand flag: 'c' in -credentials

Examples:
  # List all pods in ps output format.
  kubectl get pods
```