### PR TITLE
Configure solr images

### DIFF
--- a/ckan_cloud_operator/drivers/helm/driver.py
+++ b/ckan_cloud_operator/drivers/helm/driver.py
@@ -39,10 +39,11 @@ def init(tiller_namespace_name):
     kubectl.apply(tiller_service_account)
     kubectl.apply(cluster_role_binding)
     tiller_cmd = '' if _check_helm_version() == 3 else f' --tiller-namespace {tiller_namespace_name}'
-    subprocess.check_call(
-        f'helm init --upgrade --stable-repo-url https://charts.helm.sh/stable --service-account {tiller_namespace_name}-tiller --history-max 10' + tiller_cmd,
-        shell=True
-    )
+    if tiller_cmd:
+        subprocess.check_call(
+            f'helm init --upgrade --stable-repo-url https://charts.helm.sh/stable --service-account {tiller_namespace_name}-tiller --history-max 10' + tiller_cmd,
+            shell=True
+        )
 
 
 def deploy(tiller_namespace, chart_repo, chart_name, chart_version, release_name, values_filename=None, namespace=None,

--- a/ckan_cloud_operator/drivers/helm/driver.py
+++ b/ckan_cloud_operator/drivers/helm/driver.py
@@ -38,10 +38,9 @@ def init(tiller_namespace_name):
     }
     kubectl.apply(tiller_service_account)
     kubectl.apply(cluster_role_binding)
-    tiller_cmd = '' if _check_helm_version() == 3 else f' --tiller-namespace {tiller_namespace_name}'
-    if tiller_cmd:
+    if _check_helm_version() == 2:
         subprocess.check_call(
-            f'helm init --upgrade --stable-repo-url https://charts.helm.sh/stable --service-account {tiller_namespace_name}-tiller --history-max 10' + tiller_cmd,
+            f'helm init --upgrade --stable-repo-url https://charts.helm.sh/stable --service-account {tiller_namespace_name}-tiller --history-max 10 --tiller-namespace {tiller_namespace_name}',
             shell=True
         )
 

--- a/ckan_cloud_operator/providers/solr/solrcloud/manager.py
+++ b/ckan_cloud_operator/providers/solr/solrcloud/manager.py
@@ -81,6 +81,30 @@ def initialize(interactive=False, dry_run=False):
         config_manager.set('container-spec-overrides', '{"resources":{"limits":{"memory":"1Gi"}}}',
             configmap_name='ckan-cloud-provider-solr-solrcloud-sc-config')
 
+    # This is for setting the solr configgurations and their defaults
+    # This can modified from interactive,yaml or with pormpt answers on cluser initialize
+    solr_resources = config_manager.interactive_set(
+        {
+            'sc-cpu': '1',
+            'sc-mem': '1Gi',
+            'zk-cpu': '0.2',
+            'zk-mem': '200Mi',
+            'zn-cpu': '0.01',
+            'zn-mem': '0.01Gi',
+            'sc-cpu-limit': '2.5',
+            'sc-mem-limit': '8Gi',
+            'sc-image': 'solr:5.5.5',
+            'sc-init-image': 'alpine',
+            'zk-cpu-limit': '0.5',
+            'zk-mem-limit': '200Mi',
+            'zk-image': 'gcr.io/google_samples/k8szk:v3',
+            'zn-cpu-limit': '0.5',
+            'zn-mem-limit': '0.5Gi',
+        },
+        secret_name='solr-config',
+        interactive=interactive
+    )
+
     zk_host_names = initialize_zookeeper(interactive, dry_run=dry_run)
 
     _config_set('zk-host-names', yaml.dump(zk_host_names, default_flow_style=False))
@@ -229,6 +253,8 @@ def _apply_zookeeper_deployment(suffix, volume_spec, zookeeper_configmap_name, h
     mem_req = config_manager.get('zk-mem', secret_name='solr-config')
     cpu_lim = config_manager.get('zk-cpu-limit', secret_name='solr-config')
     mem_lim = config_manager.get('zk-mem-limit', secret_name='solr-config')
+    zk_image = config_manager.get('zk-image', secret_name='solr-config')
+
     kubectl.apply(kubectl.get_deployment(
         _get_resource_name(suffix),
         _get_resource_labels(for_deployment=True, suffix='zk'),
@@ -259,7 +285,7 @@ def _apply_zookeeper_deployment(suffix, volume_spec, zookeeper_configmap_name, h
                             'env': [
                                 {'name': 'SOLR_HOST', 'valueFrom': {'fieldRef': {'apiVersion': 'v1', 'fieldPath': 'status.podIP'}}}
                             ],
-                            'image': 'gcr.io/google_samples/k8szk:v3',
+                            'image': zk_image,
                             'livenessProbe': {
                                 'exec': {'command': ['zkOk.sh']},
                                 'failureThreshold': 3, 'initialDelaySeconds': 15, 'periodSeconds': 10,
@@ -348,6 +374,8 @@ def _apply_solrcloud_deployment(suffix, volume_spec, configmap_name, log_configm
     mem_req = config_manager.get('sc-mem', secret_name='solr-config')
     cpu_lim = config_manager.get('sc-cpu-limit', secret_name='solr-config')
     mem_lim = config_manager.get('sc-mem-limit', secret_name='solr-config')
+    sc_image = config_manager.get('sc-image', secret_name='solr-config')
+    sc_init_image = config_manager.get('sc-init-image', secret_name='solr-config')
 
     namespace = cluster_manager.get_operator_namespace_name()
     container_spec_overrides = config_manager.get('container-spec-overrides', configmap_name='ckan-cloud-provider-solr-solrcloud-sc-config',
@@ -423,7 +451,7 @@ def _apply_solrcloud_deployment(suffix, volume_spec, configmap_name, log_configm
                                     'successThreshold': 1, 'timeoutSeconds': 5
                                 },
                             }),
-                            'image': 'solr:5.5.5',
+                            'image': sc_image,
                             'ports': [
                                 {'containerPort': 8983, 'name': 'solr', 'protocol': 'TCP'},
                                 {'containerPort': 7983, 'name': 'stop', 'protocol': 'TCP'},

--- a/ckan_cloud_operator/providers/solr/solrcloud/manager.py
+++ b/ckan_cloud_operator/providers/solr/solrcloud/manager.py
@@ -82,7 +82,7 @@ def initialize(interactive=False, dry_run=False):
             configmap_name='ckan-cloud-provider-solr-solrcloud-sc-config')
 
     # This is for setting the solr configgurations and their defaults
-    # This can modified from interactive,yaml or with pormpt answers on cluser initialize
+    # This can modified from interactive,yaml or with prompt answers on cluster initialize
     solr_resources = config_manager.interactive_set(
         {
             'sc-cpu': '1',

--- a/ckan_cloud_operator/providers/solr/solrcloud/manager.py
+++ b/ckan_cloud_operator/providers/solr/solrcloud/manager.py
@@ -81,7 +81,7 @@ def initialize(interactive=False, dry_run=False):
         config_manager.set('container-spec-overrides', '{"resources":{"limits":{"memory":"1Gi"}}}',
             configmap_name='ckan-cloud-provider-solr-solrcloud-sc-config')
 
-    # This is for setting the solr configgurations and their defaults
+    # This is for setting solr's configurations and their defaults
     # This can modified from interactive,yaml or with prompt answers on cluster initialize
     solr_resources = config_manager.interactive_set(
         {

--- a/ckan_cloud_operator/providers/solr/solrcloud/manager.py
+++ b/ckan_cloud_operator/providers/solr/solrcloud/manager.py
@@ -82,8 +82,8 @@ def initialize(interactive=False, dry_run=False):
             configmap_name='ckan-cloud-provider-solr-solrcloud-sc-config')
 
     # This is for setting solr's configurations and their defaults
-    # This can modified from interactive,yaml or with prompt answers on cluster initialize
-    solr_resources = config_manager.interactive_set(
+    # This can be modified from interactive,yaml or with prompt answers on cluster initialize
+    config_manager.interactive_set(
         {
             'sc-cpu': '1',
             'sc-mem': '1Gi',

--- a/requirements.min.in
+++ b/requirements.min.in
@@ -1,5 +1,5 @@
 httpagentparser
-psycopg2
+psycopg2-binary
 pyyaml<5.3,>=5
 kubernetes
 click


### PR DESCRIPTION
let the solr images be configurable from interactive.yaml or user prompt. both solrcloud and zookeepr images can be passed from interactive.yaml on cluster initialize together with other configurations

```
//interactive.yaml
default:
  ...
  secrets:
    solr-config:
      self-hosted: y
      num-shards: "1"
      replication-factor: "3"
      sc-cpu: "1"
      sc-mem: 3Gi
      zk-cpu: "0.5"
      zk-mem: 1Gi
      sc-cpu-limit: "2"
      sc-mem-limit: 7Gi
      sc-image: solr:5.5.6
      zk-cpu-limit: "1"
      zk-mem-limit: 2Gi
```


p.s. also get rid of `helm init` for helm3